### PR TITLE
Update dependencies and add serialization support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-jetbrains-compose = "1.6.11"
-kobweb = "0.19.1-SNAPSHOT"
+jetbrains-compose = "1.7.1"
+kobweb = "0.19.3"
 kotlin = "2.0.20"
 
 [libraries]
@@ -10,6 +10,7 @@ kobweb-core = { module = "com.varabyte.kobweb:kobweb-core ", version.ref = "kobw
 kobweb-silk = { module = "com.varabyte.kobweb:kobweb-silk", version.ref = "kobweb" }
 silk-icons-fa = { module = "com.varabyte.kobwebx:silk-icons-fa", version.ref = "kobweb" }
 kobwebx-markdown = { module = "com.varabyte.kobwebx:kobwebx-markdown", version.ref = "kobweb" }
+kobwebx-serialization-kotlinx = { module = "com.varabyte.kobwebx:kobwebx-serialization-kotlinx", version.ref = "kobweb" }
 
 [plugins]
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/site/build.gradle.kts
+++ b/site/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kobweb.application)
     alias(libs.plugins.kobwebx.markdown)
+
 }
 
 repositories {
@@ -53,12 +54,14 @@ kotlin {
 
         val jsMain by getting {
             dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-stdlib-js")
                 implementation(libs.compose.html.core)
                 implementation(libs.kobweb.core)
                 implementation(libs.kobweb.silk)
                 implementation(libs.silk.icons.fa)
                 implementation(libs.kobwebx.markdown)
-             }
+                implementation(libs.kobwebx.serialization.kotlinx)
+            }
         }
     }
 }


### PR DESCRIPTION
Upgraded JetBrains Compose to 1.7.1 and Kobweb to 0.19.3. Added kotlin-stdlib-js and kobwebx-serialization-kotlinx dependencies