### PR TITLE
Fix overly broad CSS & unused parameter

### DIFF
--- a/site/src/jsMain/kotlin/com/varabyte/kobweb/site/components/widgets/navigation/HoverLink.kt
+++ b/site/src/jsMain/kotlin/com/varabyte/kobweb/site/components/widgets/navigation/HoverLink.kt
@@ -27,7 +27,7 @@ val HoverLinkStyle = CssStyle {
             .margin(left = 0.5.em)
     }
 
-    cssRule(":is(:hover > *), :focus") { Modifier.opacity(80.percent) }
+    cssRule(":is(:hover > *, :focus)") { Modifier.opacity(80.percent) }
 }
 
 /**
@@ -35,9 +35,11 @@ val HoverLinkStyle = CssStyle {
  */
 @Composable
 fun HoverLink(href: String, modifier: Modifier = Modifier) {
-    Link(href,
+    Link(
+        href,
         HoverLinkStyle.toModifier()
-            .onClick { (document.activeElement as? HTMLElement)?.clearFocus() },
+            .onClick { (document.activeElement as? HTMLElement)?.clearFocus() }
+            .then(modifier),
         UndecoratedLinkVariant.then(UncoloredLinkVariant)
     ) {
         FaLink(Modifier.display(DisplayStyle.Inline))


### PR DESCRIPTION
These were mistakenly broken in a previous refactor.