### PR TITLE
Simplify DocSearch disposal handling

### DIFF
--- a/site/build.gradle.kts
+++ b/site/build.gradle.kts
@@ -98,8 +98,7 @@ kotlin {
             implementation(libs.kobweb.silk.core)
             implementation(libs.kobweb.silk.icons.fa)
             implementation(libs.kobwebx.markdown)
-            implementation(npm("@docsearch/react", "3.9.0"))
-            implementation(npm("preact", "10.26.4"))
+            implementation(npm("@docsearch/js", "3.9.0"))
         }
     }
 }

--- a/site/webpack.config.d/config.js
+++ b/site/webpack.config.d/config.js
@@ -1,4 +1,0 @@
-
-config.resolve.alias = config.resolve.alias || {};
-config.resolve.alias['react'] = 'preact/compat';
-config.resolve.alias['react-dom'] = 'preact/compat';


### PR DESCRIPTION
Instead of manually both rendering and disposing, we can use the docsearch library for rendering and only handle the disposal logic ourselves.