### PR TITLE
Add Edit page link in docs site

### DIFF
--- a/site/src/jsMain/kotlin/com/varabyte/kobweb/site/components/layouts/DocsLayout.kt
+++ b/site/src/jsMain/kotlin/com/varabyte/kobweb/site/components/layouts/DocsLayout.kt
@@ -8,7 +8,9 @@ import com.varabyte.kobweb.compose.dom.ref
 import com.varabyte.kobweb.compose.dom.registerRefScope
 import com.varabyte.kobweb.compose.foundation.layout.Arrangement
 import com.varabyte.kobweb.compose.foundation.layout.Row
+import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.graphics.Colors
 import com.varabyte.kobweb.compose.ui.modifiers.*
 import com.varabyte.kobweb.compose.ui.toAttrs
 import com.varabyte.kobweb.core.PageContext
@@ -17,7 +19,10 @@ import com.varabyte.kobweb.core.data.add
 import com.varabyte.kobweb.core.init.InitRoute
 import com.varabyte.kobweb.core.init.InitRouteContext
 import com.varabyte.kobweb.core.layout.Layout
+import com.varabyte.kobweb.silk.components.icons.fa.FaPen
+import com.varabyte.kobweb.silk.components.navigation.Link
 import com.varabyte.kobweb.silk.components.navigation.LinkVars
+import com.varabyte.kobweb.silk.components.navigation.UndecoratedLinkVariant
 import com.varabyte.kobweb.silk.components.text.SpanText
 import com.varabyte.kobweb.silk.style.CssLayer
 import com.varabyte.kobweb.silk.style.CssStyle
@@ -25,6 +30,7 @@ import com.varabyte.kobweb.silk.style.breakpoint.Breakpoint
 import com.varabyte.kobweb.silk.style.breakpoint.displayIfAtLeast
 import com.varabyte.kobweb.silk.style.common.SmoothColorTransitionDurationVar
 import com.varabyte.kobweb.silk.style.selectors.descendants
+import com.varabyte.kobweb.silk.style.selectors.hover
 import com.varabyte.kobweb.silk.style.toModifier
 import com.varabyte.kobweb.silk.style.vars.color.BorderColorVar
 import com.varabyte.kobweb.silk.theme.colors.palette.background
@@ -199,10 +205,15 @@ fun DocsLayout(ctx: PageContext, content: @Composable () -> Unit) {
                 }
                 content()
 
+                EditPageLink(
+                    modifier = Modifier.margin { top(2.5.cssRem) },
+                    pageRoute = ctx.route.path
+                )
+
                 if (articleHandle == null) return@Article
 
                 val (prev, next) = SITE_LISTING.findArticleNeighbors(articleHandle)
-                PaginationNav(prev, next, Modifier.margin(top = 3.cssRem))
+                PaginationNav(prev, next, Modifier.margin(top = 2.cssRem))
             }
         }
         Div(
@@ -238,6 +249,42 @@ fun DocsLayout(ctx: PageContext, content: @Composable () -> Unit) {
                     .overscrollBehavior(OverscrollBehavior.Contain)
                     .scrollbarWidth(ScrollbarWidth.Thin)
             )
+        }
+    }
+}
+
+val UnderlineTextDecorationStyle = CssStyle {
+    hover {
+        Modifier.textDecorationLine(TextDecorationLine.Underline)
+    }
+}
+
+@Composable
+private fun EditPageLink(modifier: Modifier, pageRoute: String) {
+    val githubPageLink = remember {
+        val githubRepoMarkdownDirLink =
+            "https://github.com/varabyte/kobweb-site/edit/main/site/src/jsMain/resources/markdown"
+        val pathWithoutFileName = pageRoute.substringBeforeLast("/")
+
+        // NOTE: This code assumes the Markdown file doesn't set the `routeOverride` in the front matter.
+        // Expects the default (e.g., ProjectStructure.md → project-structure) so it can be
+        // converted back (e.g., project-structure → ProjectStructure.md).
+        val fileName = pageRoute.substringAfterLast("/")
+            .split("-")
+            .joinToString("") { it.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() } }
+        "${githubRepoMarkdownDirLink}/${pathWithoutFileName.removePrefix("/")}/${fileName}.md"
+    }
+    Link(
+        githubPageLink,
+        variant = UndecoratedLinkVariant,
+        modifier = Modifier.color(Colors.DodgerBlue)
+    ) {
+        Row(
+            Modifier.gap(0.4.cssRem).then(modifier),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FaPen()
+            SpanText("Edit this page", modifier = UnderlineTextDecorationStyle.toModifier())
         }
     }
 }


### PR DESCRIPTION
### Add edit page link

- *Fix #24*

<details><summary>The design is inspired by Serverpod docs site</summary>
<p>

See [this page](https://docs.serverpod.dev/tutorials/authentication).

![image](https://github.com/user-attachments/assets/aa2349d5-4d69-4b6c-a079-c3be1bf33433)

</p>
</details> 

<details><summary>The design and video demonstration</summary>
<p>

![image](https://github.com/user-attachments/assets/838375c3-9c9b-4d42-8851-4531cd20476a)

https://github.com/user-attachments/assets/2a69b8c1-9a1d-42c5-a6f9-9e808356a885

GitHub will ask the user to log in if they click the `Edit this page` link and they are not logged in on GitHub.

https://github.com/user-attachments/assets/6899c5cb-94d8-427e-b29c-cba6e6b4f1a5



</p>
</details> 