### PR TITLE
Fixed directory name for site export

### DIFF
--- a/site/src/jsMain/resources/markdown/docs/concepts/foundation/Exporting.md
+++ b/site/src/jsMain/resources/markdown/docs/concepts/foundation/Exporting.md
@@ -58,7 +58,7 @@ fun ExampleKobwebPage() {
 }
 ```
 
-Exporting generates the following HTML under your `kobweb/.site` folder, which I've reproduced here with a bunch of
+Exporting generates the following HTML under your `.kobweb/site` folder, which I've reproduced here with a bunch of
 styles elided:
 
 ```html


### PR DESCRIPTION
The docs state `kobweb/.site` but my export was found in `.kobweb/site` so I assume it was a typo.